### PR TITLE
Fixes GitHub storage adapter

### DIFF
--- a/storage/github.ts
+++ b/storage/github.ts
@@ -219,7 +219,7 @@ async function fetchInfo(
       owner,
       repo,
       path: path || "",
-      branch,
+      ref: branch,
       ...params,
     });
 


### PR DESCRIPTION
The query parameter for this uses `ref` instead of `branch` (https://docs.github.com/en/rest/repos/contents?apiVersion=2022-11-28#get-repository-content--parameters). When using `ref`, the data and the `sha` returned will match the latest commit on the contents being queried. This allows the CMS to add a commit for every subsequent update to a given file.

Re: #1 