### PR TITLE
initializes hidden input value to the schema when creating a new document/collection

### DIFF
--- a/static/components/f-hidden.js
+++ b/static/components/f-hidden.js
@@ -8,7 +8,11 @@ customElements.define(
       const { schema, value, namePrefix } = this;
       const name = `${namePrefix}.${schema.name}`;
 
-      push(this, "input", { type: "hidden", name, value });
+      push(this, "input", {
+        type: "hidden",
+        name,
+        value: value || schema.value,
+      });
     }
   },
 );

--- a/static/components/f-hidden.js
+++ b/static/components/f-hidden.js
@@ -11,7 +11,7 @@ customElements.define(
       push(this, "input", {
         type: "hidden",
         name,
-        value: value || schema.value,
+        value: value ?? schema.value,
       });
     }
   },


### PR DESCRIPTION
If a document is created but does not include the value of a hidden field, the field will be initialized with the value specified in the schema.

When a new item in a collection is created, the hidden field will be properly initialized with the value from the schema.