### PR TITLE
Remove in-memory cache for Document

### DIFF
--- a/core/cms.ts
+++ b/core/cms.ts
@@ -166,7 +166,6 @@ export default class Cms {
       content.documents[name] = new Document({
         entry: this.#getEntry(path),
         fields: this.#resolveFields(fields, content),
-        isNew: false,
         name,
         description,
       });

--- a/core/collection.ts
+++ b/core/collection.ts
@@ -14,14 +14,12 @@ export default class Collection {
   description?: string;
   #storage: Storage;
   #fields: ResolvedField[];
-  #documents: Record<string, Document>;
 
   constructor(options: CollectionOptions) {
     this.name = options.name;
     this.description = options.description;
     this.#storage = options.storage;
     this.#fields = options.fields;
-    this.#documents = {};
   }
 
   get fields() {
@@ -39,27 +37,19 @@ export default class Collection {
     return new Document({
       entry: this.#storage.get(name),
       fields: this.#fields,
-      isNew: true,
     });
   }
 
   get(id: string): Document {
-    let d = this.#documents[id];
-    if (!d) {
-      d = new Document({ entry: this.#storage.get(id), fields: this.#fields });
-      this.#documents[id] = d;
-    }
-    return d;
+    return new Document({ entry: this.#storage.get(id), fields: this.#fields });
   }
 
   async delete(id: string): Promise<void> {
     await this.#storage.delete(id);
-    delete this.#documents[id];
   }
 
   async rename(id: string, newId: string): Promise<void> {
     const newName = this.#storage.name(newId);
     await this.#storage.rename(id, newName);
-    delete this.#documents[id];
   }
 }

--- a/core/collection.ts
+++ b/core/collection.ts
@@ -37,6 +37,7 @@ export default class Collection {
     return new Document({
       entry: this.#storage.get(name),
       fields: this.#fields,
+      isNew: true,
     });
   }
 

--- a/core/document.ts
+++ b/core/document.ts
@@ -5,7 +5,6 @@ export interface DocumentOptions {
   description?: string;
   entry: Entry;
   fields: ResolvedField[];
-  isNew?: boolean;
 }
 
 export default class Document {
@@ -13,17 +12,12 @@ export default class Document {
   description?: string;
   #entry: Entry;
   #fields: ResolvedField[];
-  #data?: Data;
 
   constructor(options: DocumentOptions) {
     this.#name = options.name;
     this.description = options.description;
     this.#entry = options.entry;
     this.#fields = options.fields;
-
-    if (options.isNew) {
-      this.#data = {};
-    }
   }
 
   get fields() {
@@ -39,11 +33,7 @@ export default class Document {
   }
 
   async read() {
-    if (this.#data === undefined) {
-      this.#data = await this.#entry.readData();
-    }
-
-    return this.#data;
+    return await this.#entry.readData();
   }
 
   async write(data: Data) {
@@ -53,7 +43,6 @@ export default class Document {
       await field.applyChanges(currentData, data, field);
     }
 
-    this.#data = currentData;
     await this.#entry.writeData(currentData);
   }
 }

--- a/core/document.ts
+++ b/core/document.ts
@@ -5,6 +5,7 @@ export interface DocumentOptions {
   description?: string;
   entry: Entry;
   fields: ResolvedField[];
+  isNew?: boolean;
 }
 
 export default class Document {
@@ -12,12 +13,14 @@ export default class Document {
   description?: string;
   #entry: Entry;
   #fields: ResolvedField[];
+  #isNew?: boolean;
 
   constructor(options: DocumentOptions) {
     this.#name = options.name;
     this.description = options.description;
     this.#entry = options.entry;
     this.#fields = options.fields;
+    this.#isNew = options.isNew;
   }
 
   get fields() {
@@ -33,6 +36,9 @@ export default class Document {
   }
 
   async read() {
+    if (this.#isNew) {
+      return {};
+    }
     return await this.#entry.readData();
   }
 
@@ -44,5 +50,6 @@ export default class Document {
     }
 
     await this.#entry.writeData(currentData);
+    this.#isNew = false;
   }
 }


### PR DESCRIPTION
I see that the CMS maintains an in-memory cache for Documents but I think there is a bug with maintaining it for Collections. I think the intention was to also maintain in-memory cache for Collections. 

`Document` in-memory cache [works from here](https://github.com/lumeland/cms/blob/main/core/document.ts#L41-L47).

This PR contains a fix for the Collection in-memory cache.

**Additionally**
What do you think about providing a CMS configuration that toggles in-memory cache? It seems like a nice feature provide some control over. I'd like to disable in-memory cache and use the fetch the item from storage each time.