### PR TITLE
Added autocompletion to field types

### DIFF
--- a/core/cms.ts
+++ b/core/cms.ts
@@ -26,7 +26,7 @@ import type {
   CMSContent,
   Entry,
   Field,
-  FielType,
+  FieldType,
   ResolvedField,
   SiteInfo,
   Storage,
@@ -86,7 +86,7 @@ export default class Cms {
   options: CmsOptions;
   storages = new Map<string, Storage | string>();
   uploads = new Map<string, [string, string]>();
-  fields = new Map<string, FielType>();
+  fields = new Map<string, FieldType>();
   collections = new Map<string, CollectionOptions>();
   documents = new Map<string, DocumentOptions>();
   versionManager: Versioning | undefined;
@@ -180,7 +180,7 @@ export default class Cms {
     return this;
   }
 
-  field(name: string, field: FielType): this {
+  field(name: string, field: FieldType): this {
     this.fields.set(name, field);
     return this;
   }

--- a/fields/core.ts
+++ b/fields/core.ts
@@ -3,8 +3,6 @@ import { isEmpty } from "../core/utils/string.ts";
 
 import type { Data, FielType, ResolvedField } from "../types.ts";
 
-const fields = new Map<string, FielType>();
-
 // Logic-less fields
 const inputs = {
   text: null,
@@ -25,8 +23,14 @@ const inputs = {
   number: (v: string) => Number(v),
 };
 
+type DumpFieldKeys = keyof typeof inputs;
+type SmartFieldKeys = "list" | "object" | "object-list" | "choose-list" | "file";
+export type FieldKeys = DumpFieldKeys | SmartFieldKeys;
+
+const fields = new Map<FieldKeys, FielType>();
+
 for (const [input, transform] of Object.entries(inputs)) {
-  fields.set(input, {
+  fields.set(input as DumpFieldKeys, {
     tag: `f-${input}`,
     jsImport: `lume_cms/components/f-${input}.js`,
     applyChanges(data, changes, field: ResolvedField) {

--- a/fields/core.ts
+++ b/fields/core.ts
@@ -24,7 +24,12 @@ const inputs = {
 };
 
 type DumpFieldKeys = keyof typeof inputs;
-type SmartFieldKeys = "list" | "object" | "object-list" | "choose-list" | "file";
+type SmartFieldKeys =
+  | "list"
+  | "object"
+  | "object-list"
+  | "choose-list"
+  | "file";
 export type FieldKeys = DumpFieldKeys | SmartFieldKeys;
 
 const fields = new Map<FieldKeys, FieldType>();

--- a/types.ts
+++ b/types.ts
@@ -2,6 +2,7 @@
 import type Collection from "./core/collection.ts";
 import type Document from "./core/document.ts";
 import type Upload from "./core/upload.ts";
+import { FieldKeys } from "./fields/core.ts";
 
 /** Generic data to store */
 export type Data = Record<string, unknown>;
@@ -59,7 +60,9 @@ export interface Transformer<T> {
 
 /** The schema for a field */
 export interface Field {
-  type: string;
+  type: FieldKeys | (string & Record<never, never>);
+  //                ^ Typescript hack to suggest the correct keys but allow any string
+  //                  https://x.com/diegohaz/status/1524257274012876801
   name: string;
   value?: unknown;
   fields?: (Field | string)[];


### PR DESCRIPTION
This PR adds autocompletion to the `type` attribute of a field.

Without this PR:
<img width="638" alt="image" src="https://github.com/user-attachments/assets/16bea9ae-6ae5-4db1-8474-08389150489e">

With this PR:
<img width="648" alt="image" src="https://github.com/user-attachments/assets/d4221732-34af-43ef-ba49-b70da9445311">
