### PR TITLE
feat: name files dynamically from the created fields

### DIFF
--- a/core/cms.ts
+++ b/core/cms.ts
@@ -24,6 +24,7 @@ import { dispatch } from "./utils/event.ts";
 import type { Context, Next } from "../deps/hono.ts";
 import type {
   CMSContent,
+  Data,
   Entry,
   Field,
   FieldType,
@@ -76,7 +77,7 @@ interface CollectionOptions {
   fields: (Field | string)[];
   url?: string;
   views?: string[];
-  nameField?: string | ((changedFields: Record<string, string>) => string);
+  nameField?: string | ((changes: Data) => string);
   create?: boolean;
   delete?: boolean;
 }

--- a/core/cms.ts
+++ b/core/cms.ts
@@ -76,7 +76,7 @@ interface CollectionOptions {
   fields: (Field | string)[];
   url?: string;
   views?: string[];
-  nameField?: string;
+  nameField?: string | ((changedFields: Record<string, string>) => string);
   create?: boolean;
   delete?: boolean;
 }

--- a/core/collection.ts
+++ b/core/collection.ts
@@ -9,7 +9,7 @@ export interface CollectionOptions {
   fields: ResolvedField[];
   url?: string;
   views?: string[];
-  nameField?: string;
+  nameField?: string | ((changedFields: Record<string, string>) => string);
   create?: boolean;
   delete?: boolean;
 }
@@ -26,7 +26,7 @@ export default class Collection {
   #fields: ResolvedField[];
   url?: string;
   views?: string[];
-  nameField?: string;
+  nameField?: string | ((changedFields: Record<string, string>) => string);
   permissions: Permissions;
 
   constructor(options: CollectionOptions) {

--- a/core/collection.ts
+++ b/core/collection.ts
@@ -1,6 +1,6 @@
 import Document from "./document.ts";
 
-import type { EntryMetadata, ResolvedField, Storage } from "../types.ts";
+import type { Data, EntryMetadata, ResolvedField, Storage } from "../types.ts";
 
 export interface CollectionOptions {
   name: string;
@@ -9,7 +9,7 @@ export interface CollectionOptions {
   fields: ResolvedField[];
   url?: string;
   views?: string[];
-  nameField?: string | ((changedFields: Record<string, string>) => string);
+  nameField?: string | ((changes: Data) => string);
   create?: boolean;
   delete?: boolean;
 }
@@ -26,7 +26,7 @@ export default class Collection {
   #fields: ResolvedField[];
   url?: string;
   views?: string[];
-  nameField?: string | ((changedFields: Record<string, string>) => string);
+  nameField?: string | ((changes: Data) => string);
   permissions: Permissions;
 
   constructor(options: CollectionOptions) {

--- a/core/routes/collection.ts
+++ b/core/routes/collection.ts
@@ -158,7 +158,7 @@ export default function (app: Hono) {
       if (!name && collection.nameField) {
         switch (typeof collection.nameField) {
           case "string": {
-            const autoname = changes[collection.nameField];
+            const autoname = body[`changes.${collection.nameField}`];
             if (typeof autoname === "string") {
               name = autoname.replaceAll("/", "").trim();
             }

--- a/core/routes/collection.ts
+++ b/core/routes/collection.ts
@@ -156,21 +156,18 @@ export default function (app: Hono) {
 
       const namePrefix = "changes."
       if (!name && collection.nameField) {
-        if (typeof collection.nameField === "string") {
-          const autoname = body[`${namePrefix}${collection.nameField}`];
-
-          if (typeof autoname === "string") {
-            name = autoname.replaceAll("/", "").trim();
-          }
-        } else if (typeof collection.nameField === "function") {
-          const changedFields: Record<string, string> = {};
-          for (const key in body) {
-            if (key.startsWith(namePrefix) && typeof body[key] === "string") {
-              changedFields[key.substring(namePrefix.length)] = body[key];
+        switch (typeof collection.nameField) {
+          case "string": {
+            const autoname = body[`${namePrefix}${collection.nameField}`];
+            if (typeof autoname === "string") {
+              name = autoname.replaceAll("/", "").trim();
             }
+            break;
           }
-
-          name = collection.nameField(changedFields);
+          case "function": {
+            name = collection.nameField(changesToData(body));
+            break;
+          }
         }
       }
 

--- a/core/routes/collection.ts
+++ b/core/routes/collection.ts
@@ -154,18 +154,18 @@ export default function (app: Hono) {
       const body = await c.req.parseBody();
       let name = body._id as string;
 
-      const namePrefix = "changes."
+      const changes = changesToData(body);
       if (!name && collection.nameField) {
         switch (typeof collection.nameField) {
           case "string": {
-            const autoname = body[`${namePrefix}${collection.nameField}`];
+            const autoname = changes[collection.nameField];
             if (typeof autoname === "string") {
               name = autoname.replaceAll("/", "").trim();
             }
             break;
           }
           case "function": {
-            name = collection.nameField(changesToData(body));
+            name = collection.nameField(changes);
             break;
           }
         }
@@ -180,7 +180,7 @@ export default function (app: Hono) {
       }
 
       const document = collection.create(name);
-      await document.write(changesToData(body), true);
+      await document.write(changes, true);
 
       return c.redirect(
         getPath(

--- a/core/routes/collection.ts
+++ b/core/routes/collection.ts
@@ -154,11 +154,23 @@ export default function (app: Hono) {
       const body = await c.req.parseBody();
       let name = body._id as string;
 
+      const namePrefix = "changes."
       if (!name && collection.nameField) {
-        const autoname = body[`changes.${collection.nameField}`];
+        if (typeof collection.nameField === "string") {
+          const autoname = body[`${namePrefix}${collection.nameField}`];
 
-        if (typeof autoname === "string") {
-          name = autoname.replaceAll("/", "").trim();
+          if (typeof autoname === "string") {
+            name = autoname.replaceAll("/", "").trim();
+          }
+        } else if (typeof collection.nameField === "function") {
+          const changedFields: Record<string, string> = {};
+          for (const key in body) {
+            if (key.startsWith(namePrefix) && typeof body[key] === "string") {
+              changedFields[key.substring(namePrefix.length)] = body[key];
+            }
+          }
+
+          name = collection.nameField(changedFields);
         }
       }
 


### PR DESCRIPTION
This PR extend `nameField` option to generate the file name from the created fields dynamically.

```js
cms.collection({
  name: "Articles",
  store: "src:articles/**/*.md",
  fields: [
    "title: text",
    "description: text",
  ],
  nameField: (changedFields) => new Date().toISOString() + changedFields.title
});
```

Ref: https://discord.com/channels/794537085641818124/1213641439133835304/1290507591881068615