### PR TITLE
Feat: UI changes

### DIFF
--- a/core/templates/layout.vto
+++ b/core/templates/layout.vto
@@ -48,7 +48,7 @@
     </div>
     <footer class="app-footer">
       <p>
-        Powered by <a href="https://lume.land/cms/">LumeCMS {{ version }}</a>
+        Powered by <a href="https://lume.land/cms/">LumeCMS {{ version |> slice(0, 7) }}</a>
       </p>
       <button
         class="buttonIcon"

--- a/static/components/f-markdown.js
+++ b/static/components/f-markdown.js
@@ -106,6 +106,8 @@ customElements.define(
         [md.makeH2, "text-h-two"],
         [md.makeH3, "text-h-three"],
         [md.makeH4, "text-h-four"],
+        [md.makeH5, "text-h-five"],
+        [md.makeH6, "text-h-six"],
       ].forEach(([fn, icon]) => {
         dom("button", {
           class: "buttonIcon",

--- a/static/components/f-markdown.js
+++ b/static/components/f-markdown.js
@@ -105,9 +105,7 @@ customElements.define(
         [md.makeH1, "text-h-one"],
         [md.makeH2, "text-h-two"],
         [md.makeH3, "text-h-three"],
-        [md.makeH4, "text-h-four"],
-        [md.makeH5, "text-h-five"],
-        [md.makeH6, "text-h-six"],
+        [md.makeH4, "text-h-four"]
       ].forEach(([fn, icon]) => {
         dom("button", {
           class: "buttonIcon",


### PR DESCRIPTION
### Problem 1
When using a version of a Git hash e.g. 
`import("https://cdn.jsdelivr.net/gh/lumeland/cms@d79b3738383502bc21feddc67d8fffd1e47d06e6/mod.ts")`

The footer displays the full hash which looks a bit weird and takes up a lot of space

#### Solution
Only show first 7 chars of version

---

### Problem 2
Markdown editor doesn't allow for full .md standard heading levels e.g. h1 - h6

#### Solution
Added h5 and h6 to markdown editor