### PR TITLE
fix: Malformed JSON (Don't parse empty JSON files)

### DIFF
--- a/storage/transformers/json.ts
+++ b/storage/transformers/json.ts
@@ -3,6 +3,9 @@ import type { Transformer } from "../../types.ts";
 
 export const Json: Transformer<string> = {
   toData(content) {
+    if (!content) {
+      return {}; // fix/malformed-json - if content is empty don't parse it
+    }
     try {
       return JSON.parse(content) as Record<string, unknown>;
     } catch (error) {


### PR DESCRIPTION
Before: When creating a file, the CMS would first fetch and read it. Then it would parse it with the JSON transformer if using JSON If the file didn't exist, it would try and parse nothing which always returned an error.

Error always returned from create document:
```
Malformed JSON code: Unexpected end of JSON input...
```

Now: Checks if the content passed to the JSON transformer is empty. If so then do not parse and return an empty object `{}`