### PR TITLE
fix: replace import with fetch to appease denodeploy

### DIFF
--- a/static/common/locale.js
+++ b/static/common/locale.js
@@ -1,10 +1,9 @@
 const locale = new Map();
 
 export async function setLocale(lang) {
-  const { default: entries } = await import(
-    `./locale/${lang}.json`,
-    { with: { type: "json" } }
-  );
+  const url = new URL(`./locale/${lang}.json`, import.meta.url);
+  const response = await fetch(url);
+  const entries = await response.json();
 
   locale.clear();
   for (const [key, value] of Object.entries(entries)) {


### PR DESCRIPTION
On one hand, Deno Deploy's runtime is strictly forbidden from downloading new modules over the network while the app is actively running. On the other, It can't analyze a dynamic import with a variable string during the build and deployment phase. In the end, it does not download the JSON files into the deployment bundle, and we end-up with an error:

```
TypeError: Module not found
    at async setLocale (https://cdn.jsdelivr.net/gh/esroyo/cms@eaf17bd/static/common/locale.js:4:32)
    at async https://cdn.jsdelivr.net/gh/esroyo/cms@eaf17bd/core/routes/main.ts:80:7
    at async Router.#runHandler (https://deno.land/x/galo@v0.3.4/mod.ts:437:24)
    at async Router.#runRouter (https://deno.land/x/galo@v0.3.4/mod.ts:372:14)
    at async mapped (ext:deno_http/00_serve.ts:407:18) {
  code: "ERR_MODULE_NOT_FOUND"
}
```

@oscarotero would you mind replacing the beautiful locales dynamic `import()` with a nasty `fetch`? :sweat: 